### PR TITLE
Allow flexible Nokogiri versioning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pkg
 .idea/
 .yardoc
+*.gem

--- a/danger-rubocop_junit_parser.gemspec
+++ b/danger-rubocop_junit_parser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.8.2'
+  spec.add_runtime_dependency 'nokogiri', '>= 1.8.2'
 
   # General ruby development
   spec.add_development_dependency 'bundler', '~> 1.3'

--- a/lib/rubocop_junit_parser/gem_version.rb
+++ b/lib/rubocop_junit_parser/gem_version.rb
@@ -1,3 +1,3 @@
 module RubocopJunitParser
-  VERSION = "0.0.1".freeze
+  VERSION = "0.0.2".freeze
 end


### PR DESCRIPTION
this was locking nokogiri to a legacy version. already released a new version of it - https://rubygems.org/gems/danger-rubocop_junit_parser